### PR TITLE
feat: add style config in talend packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,11 +37,11 @@ function main(moduleName, version, options) {
     const env = options.env || 'development';
 
     if (typeof moduleName !== 'string') {
-        throw new TypeError("Expected 'moduleName' to be a string");
+        throw new TypeError('Expected \'moduleName\' to be a string');
     }
 
     if (typeof version !== 'string') {
-        throw new TypeError("Expected 'version' to be a string");
+        throw new TypeError('Expected \'version\' to be a string');
     }
 
     const isModuleAvailable = moduleName in modules;

--- a/index.js
+++ b/index.js
@@ -37,11 +37,11 @@ function main(moduleName, version, options) {
     const env = options.env || 'development';
 
     if (typeof moduleName !== 'string') {
-        throw new TypeError('Expected \'moduleName\' to be a string');
+        throw new TypeError("Expected 'moduleName' to be a string");
     }
 
     if (typeof version !== 'string') {
-        throw new TypeError('Expected \'version\' to be a string');
+        throw new TypeError("Expected 'version' to be a string");
     }
 
     const isModuleAvailable = moduleName in modules;
@@ -50,10 +50,10 @@ function main(moduleName, version, options) {
         return null;
     }
 
-    const module = modules[moduleName];
-    const range = Object.keys(module.versions).find(range => semver.satisfies(version, range));
-    const config = module.versions[range];
-    const styleConfig = module['style-versions'] && module['style-versions'][range];
+    const moduleConf = modules[moduleName];
+    const range = Object.keys(moduleConf.versions).find(range => semver.satisfies(version, range));
+    const config = moduleConf.versions[range];
+    const styleConfig = moduleConf['style-versions'] && moduleConf['style-versions'][range];
 
     if (config == null) {
         return null;

--- a/test.js
+++ b/test.js
@@ -13,7 +13,9 @@ test('basic', t => {
         url: 'https://unpkg.com/react@15.0.0/dist/react.js',
         version: '15.0.0',
         path: '/dist/react.js',
-        local: pathModule.join(__dirname, 'node_modules', 'react', '/dist/react.js')
+        local: pathModule.join(__dirname, 'node_modules', 'react', '/dist/react.js'),
+        stylePath: undefined,
+        styleUrl: undefined
     });
 });
 
@@ -22,11 +24,14 @@ test('getAllModules', t => {
 });
 
 test('unpkg', t => {
-    t.is(fn.unpkg({
-        name: 'react',
-        version: '15.0.0',
-        path: '/foo/bar'
-    }), 'https://unpkg.com/react@15.0.0/foo/bar');
+    t.is(
+        fn.unpkg({
+            name: 'react',
+            version: '15.0.0',
+            path: '/foo/bar'
+        }),
+        'https://unpkg.com/react@15.0.0/foo/bar'
+    );
 });
 
 test('unknown module', t => {
@@ -49,7 +54,9 @@ test('module not installed', t => {
         url: 'https://unpkg.com/react-dom@15.0.0/dist/react-dom.js',
         version: '15.0.0',
         path: '/dist/react-dom.js',
-        local: undefined
+        local: undefined,
+        stylePath: undefined,
+        styleUrl: undefined
     });
 });
 


### PR DESCRIPTION
Issue:
In case a library has been built using webpack with CSS extracted and put css file side by side with the UMD bundle
we can t build anything on top of it.

Solution:
Add configuration support to add style path.
