### PR TITLE
feat: add proxy support

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,25 +32,38 @@ function add(config) {
     });
 }
 
-function main(moduleName, version, options) {
+function getModuleName(importPath) {
+    const isScoped = importPath.startsWith('@');
+    const splitted = importPath.split('/');
+    if ((isScoped && splitted.length < 3) || (!isScoped && splitted.length < 2)) {
+        return importPath;
+    }
+    if (isScoped) {
+        return `${splitted[0]}/${splitted[1]}`;
+    }
+    return splitted[0];
+}
+
+function main(importPath, version, options) {
     options = options || {};
     const env = options.env || 'development';
 
-    if (typeof moduleName !== 'string') {
-        throw new TypeError('Expected \'moduleName\' to be a string');
+    if (typeof importPath !== 'string') {
+        throw new TypeError("Expected 'importPath' to be a string");
     }
 
     if (typeof version !== 'string') {
-        throw new TypeError('Expected \'version\' to be a string');
+        throw new TypeError("Expected 'version' to be a string");
     }
 
-    const isModuleAvailable = moduleName in modules;
+    const isModuleAvailable = importPath in modules;
 
     if (!isModuleAvailable) {
         return null;
     }
 
-    const moduleConf = modules[moduleName];
+    const moduleName = getModuleName(importPath);
+    const moduleConf = modules[importPath];
     const range = Object.keys(moduleConf.versions).find(range => semver.satisfies(version, range));
     const config = moduleConf.versions[range];
     const styleConfig = moduleConf['style-versions'] && moduleConf['style-versions'][range];
@@ -95,7 +108,7 @@ function main(moduleName, version, options) {
 
     return {
         name: moduleName,
-        var: modules[moduleName].var || modules[moduleName].versions[range].var,
+        var: modules[importPath].var || modules[importPath].versions[range].var,
         url,
         version,
         path,
@@ -114,4 +127,5 @@ main.unpkg = getURL;
 main.add = add;
 main.getAllModules = getAllModules;
 main.cache = cache;
+main.getModuleName = getModuleName;
 module.exports = main;

--- a/index.js
+++ b/index.js
@@ -38,9 +38,11 @@ function getModuleName(importPath) {
     if ((isScoped && splitted.length < 3) || (!isScoped && splitted.length < 2)) {
         return importPath;
     }
+
     if (isScoped) {
         return `${splitted[0]}/${splitted[1]}`;
     }
+
     return splitted[0];
 }
 

--- a/modules.json
+++ b/modules.json
@@ -29,7 +29,7 @@
   "@angular/common/http": {
     "var": "ng.common.http",
     "versions": {
-      ">=2.1.0 < 3.0.0 || >= 4.0.0": {
+      "> 4.3.6": {
         "development": "/bundles/common-http.umd.js",
         "production": "/bundles/common-http.umd.min.js"
       }
@@ -763,6 +763,15 @@
       ">= 1.0.0": {
         "development": "/dist/redux-saga.umd.js",
         "production": "/dist/redux-saga.umd.min.js"
+      }
+    }
+  },
+  "redux-saga/effects": {
+    "var": "ReduxSagaEffects",
+    "versions": {
+      ">= 1.0.5": {
+        "development": "/dist/redux-saga-effects.umd.js",
+        "production": "/dist/redux-saga-effects.umd.min.js"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "rules": {
       "ava/no-ignored-test-files": "off",
       "eqeqeq": "off",
+      "quotes": "off",
       "no-eq-null": "off",
       "node/no-unsupported-features/es-syntax": "off",
       "unicorn/no-reduce": "off"


### PR DESCRIPTION
Current module works well with a one one relation:
path === nodule name

but modules can be deeply imported and in some case this is the official way of using them

For example this is the case of redux-saga/effects, @angular/common/http

But moduleToCdn fails on this and do not give any difference between the two